### PR TITLE
Prevent double-encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,6 @@ class instance extends instance_skel {
 
 		tServer.on('connection', (socket) => {
 			let cid = socket.remoteAddress + ":" + socket.remotePort;
-			socket.setEncoding('latin1');
 			this.tSockets.push(socket);
 			this.updateVariables();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-tcp-serial",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generic IP to serial interface module",
   "main": "index.js",
   "manufacturer": "Generic",


### PR DESCRIPTION
Removed extra `setencoding` to prevent re-encoding raw buffer to UTF16