### PR TITLE
Add another attribute to port 'exists' check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-tcp-serial",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
The `serialport` library changed (again).
On Linux, all 20 reserved 'tty' ports are included with a port list request.
In order to shorten the list, the module checks a couple of extra attributes: 
`(p.locationId || p.pnpId)` 
before assuming the port exists and adding it to the selection/dropdown.
Ubuntu: `path: /dev/ttyUSB0, manufacturer: 067b, serialNumber: undefined, pnpId: usb-067b_2303-if00-port0, locationId: undefined, vendorId: 067b, productId: 2303`
Pi: `path: /dev/ttyUSB0, manufacturer: undefined, serialNumber: undefined, pnpId: undefined, locationId: undefined, vendorId: 1106, productId: 3483`
The new scan checks `(p.locationId || p.vendorId || p.pnpId)` 
FWIW The library docs state that `path` is the only attribute that WILL contain something.