### PR TITLE
Allow custom path for serial device port

### DIFF
--- a/choices.js
+++ b/choices.js
@@ -1,20 +1,16 @@
 // serial port configuration choices
-export const BAUD_RATES =
-[9600, 14400, 19200, 38400, 57600, 115200, 110, 300, 1200, 2400, 4800].map( (v) => {
-	return { id: v, label: v + ' Baud'};
-});
+export const BAUD_RATES = [9600, 14400, 19200, 38400, 57600, 115200, 110, 300, 1200, 2400, 4800].map((v) => {
+	return { id: v, label: v + ' Baud' }
+})
 
-export const BITS =
-[8,7,6,5].map ( (v) => {
-	return { id: v, label: v + ' Bits'};
-});
+export const BITS = [8, 7, 6, 5].map((v) => {
+	return { id: v, label: v + ' Bits' }
+})
 
-export const PARITY =
-['None','Even','Odd','Mark','Space'].map( (v) => {
-	return { id: v.toLowerCase(), label: v};
-});
+export const PARITY = ['None', 'Even', 'Odd', 'Mark', 'Space'].map((v) => {
+	return { id: v.toLowerCase(), label: v }
+})
 
-export const STOP =
-[1, 2].map ( (v) => {
-	return { id: v, label: v + ' Bits'};
-});
+export const STOP = [1, 2].map((v) => {
+	return { id: v, label: v + ' Bits' }
+})

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -1,4 +1,5 @@
-## Generic TCP Serial Module
+# Generic TCP Serial Module
+
 A generic module to forward a TCP connection to an attached serial/comm/rs232/rs485 port
 
 This is a Serial (RS232) to TCP bridge for Companion. By itself it is not very useful.
@@ -11,31 +12,35 @@ This module allows 4 incoming TCP connections. It may be possible to confuse the
 
 --------
 Contributions for maintenance and development of this open source module are always welcome
-https://github.com/sponsors/istnv
+<https://github.com/sponsors/istnv>
 
 --------
 
-### Traffic Flow
+## Traffic Flow
+
 * Data coming from a TCP client is forwarded as-is _ONLY_ to the serial port. This prevents other clients from seeing commands that may not correspond to device feedback notifications.
 * Data coming from the serial port is sent as-is to _ALL_ connected TCP clients. This allows all clients to adjust feedback/variables if possible or necessary.
 
-
 ## Configuration
+
 Setting | Description
 -----------------|---------------
 **Listen Port** | Enter the IP Port number to listen for a TCP connection. Defaults to 32100 and will need to be changed if more than one serial port is to be configured.
-**Serial Port** | Choose the Serial port attached to the device [1]
+**Serial Port** | Choose the Serial port attached to the device [1] [2]
 **Baud Rate** | Choose the baud rate for the serial port
 **Data Bits** | Choose the data bits for the serial port
 **Parity** | Choose the parity for the serial port
 **Stop Bits** | Choose the stop bits for the serial port
 
 ## Variables
+
 Variable | Description
 -----|-----
 ip_add | Address of the clients connected to the TCP server
 
+--------
 This is a helper to assist other modules. There are no actions.
 
 [1] When the module first starts up, it will scan the system for serial ports. Until ports are found, the configuration drop-down menu will be empty or not available. The log will show 'No serial port configured' when the scan is complete.
 
+[2] You can optionally type the full path to the OS locaton of the serial device. Incorrect values will not work.

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ class TSPInstance extends InstanceBase {
 			// make sure client is connected
 			if (this.tSockets.length > 0) {
 				// forward data to the TCP connection (data is a buffer)
-				this.log('debug', 'COM> ' + toHex(data.toString('latin1') + ' '))
+				this.log('debug', 'COM> ' + toHex(data.toString('latin1')) + ' ')
 				this.tSockets.forEach((sock) => sock.write(data))
 			}
 			clearInterval(this.SERIAL_INTERVAL)
@@ -524,10 +524,11 @@ class TSPInstance extends InstanceBase {
 			fields.push(
 				{
 					type: 'dropdown',
+          allowCustom: true,
 					id: 'sport',
 					label: 'Serial port',
 					width: 12,
-					default: ports[0].id,
+					value: ports[ports.length==1 ? 0 : 1].id,
 					choices: ports,
 				},
 				{
@@ -535,7 +536,7 @@ class TSPInstance extends InstanceBase {
 					id: 'baud',
 					label: 'Baud Rate',
 					width: 6,
-					default: CHOICES.BAUD_RATES.slice(0,1).id,
+					value: CHOICES.BAUD_RATES[0].id,
 					choices: CHOICES.BAUD_RATES,
 				},
 				{
@@ -543,7 +544,7 @@ class TSPInstance extends InstanceBase {
 					id: 'bits',
 					label: 'Data Bits',
 					width: 6,
-					default: CHOICES.BITS.slice(0,1).id,
+					value: CHOICES.BITS[0].id,
 					choices: CHOICES.BITS,
 				},
 				{
@@ -551,7 +552,7 @@ class TSPInstance extends InstanceBase {
 					id: 'parity',
 					label: 'Parity',
 					width: 6,
-					default: CHOICES.PARITY.slice(0,1).id,
+					value: CHOICES.PARITY[0].id,
 					choices: CHOICES.PARITY,
 				},
 				{
@@ -559,7 +560,7 @@ class TSPInstance extends InstanceBase {
 					id: 'stop',
 					label: 'Stop Bits',
 					width: 6,
-					default: CHOICES.STOP.slice(0,1).id,
+					value: CHOICES.STOP[0].id,
 					choices: CHOICES.STOP,
 				}
 			)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-tcp-serial",
-	"version": "2.3.1",
+	"version": "2.4.0",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
When more than one USB to serial adapter is attached to a Linux system, port names are not always consistent.
Adding a `udev` rule using a unique device id allows a consistent symlink to be created. 
This is a shortcut and not an actual device node so it does not get included in the scanned port list.
This patch allows a custom path to be entered directly.