### PR TITLE
Add option to show all ports

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -26,6 +26,7 @@ Contributions for maintenance and development of this open source module are alw
 Setting | Description
 -----------------|---------------
 **Listen Port** | Enter the IP Port number to listen for a TCP connection. Defaults to 32100 and will need to be changed if more than one serial port is to be configured.
+**Show Native (non-USB) Ports** | Include native (on-board) ports in selection [3]
 **Serial Port** | Choose the Serial port attached to the device [1] [2]
 **Baud Rate** | Choose the baud rate for the serial port
 **Data Bits** | Choose the data bits for the serial port
@@ -44,3 +45,5 @@ This is a helper to assist other modules. There are no actions.
 [1] When the module first starts up, it will scan the system for serial ports. Until ports are found, the configuration drop-down menu will be empty or not available. The log will show 'No serial port configured' when the scan is complete.
 
 [2] You can optionally type the full path to the OS locaton of the serial device. Incorrect values will not work.
+
+[3] On Linux (and Pi) this will show many 'phantom' ports that are not connected to anything.

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ class TSPInstance extends InstanceBase {
 		this.tSockets = []
 		this.sPortPath = 'none'
 		this.isOpen = false
+		this.allPorts = false
 		this.IPPort = 32100
 		this.devMode = process.env.DEVELOPER
 	}
@@ -124,6 +125,7 @@ class TSPInstance extends InstanceBase {
 		this.config = config
 		this.clearAll()
 		this.isListening = false
+		this.allPorts = config.showAll || false
 		this.IPPort = config.iport || 32100
 		this.sPortPath = config.sport || 'none'
 		this.tSockets = []
@@ -193,7 +195,7 @@ class TSPInstance extends InstanceBase {
 
 		this.sPort.open()
 
-		this.doUpdateStatus()
+		//this.doUpdateStatus()
 	}
 
 	/**
@@ -354,8 +356,9 @@ class TSPInstance extends InstanceBase {
 						for (const [k, v] of Object.entries(p)) {
 							nb += (nb == '' ? '' : ', ') + `${k}: ${v}`
 						}
+						this.log('debug', nb)
 					}
-					if (p.locationId || p.vendorId || p.pnpId) {
+					if (this.allPorts || p.locationId || p.vendorId || p.pnpId) {
             let path = p.path ? p.path : p.comName
             let manu = p.manufacturer ? p.manufacturer : 'Internal'
 						this.foundPorts.push({
@@ -493,6 +496,13 @@ class TSPInstance extends InstanceBase {
 				default: this.IPPort,
 				regex: Regex.PORT,
 			},
+			{
+				type: 'checkbox',
+				id: 'showAll',
+				label: 'Show Native (non-USB) Ports',
+				default: false,
+				width: 12,
+			}
 		]
 
 		if (this.foundPorts.length == 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-tcp-serial",
-	"version": "2.4.1",
+	"version": "2.5.0",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Adds option to show all ports.
Linux systems pre-define many serial ports that do not necessarily correspond to actual hardware.
This allows access for systems that have a built in comm port.